### PR TITLE
Add "deploy to Heroku" button

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app -w 2 --log-file=- --access-logfile=-

--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ $ docker-compose exec web python
 
 $ docker-compose logs -f
 ```
+
+### Heroku
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)

--- a/app.json
+++ b/app.json
@@ -1,0 +1,10 @@
+{
+    "name": "CloudZoo Issuer Example",
+    "description": "A starting point for a third-party Cloud Zoo issuer",
+    "repository": "https://github.com/mcneel/cloudzoo-issuer",
+    "keywords": ["rhino3d", "cloudzoo", "license"],
+    "addons": ["heroku-postgresql"],
+    "scripts": {
+        "postdeploy": "python -c \"from app import db; db.create_all()\""
+    }
+}


### PR DESCRIPTION
Adds a "deploy to heroku" button to the readme

Uses app.json to deploy the app along with a postgres database
(DATABASE_URL set automatically) and launches as per the Procfile